### PR TITLE
Added the word, Lambda, to templates that were missing it. Issue 1396.

### DIFF
--- a/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabelsServerless-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabelsServerless-FSharp/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Serverless Detect Image Labels",
+  "name": "Lambda Serverless Detect Image Labels",
   "identity": "AWS.Lambda.Serverless.DetectImageLabels.FSharp",
   "groupIdentity": "AWS.Lambda.Serverless.DetectImageLabels",
   "shortName": "serverless.DetectImageLabels",

--- a/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabelsServerless/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2017/DetectImageLabelsServerless/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Serverless Detect Image Labels",
+  "name": "Lambda Serverless Detect Image Labels",
   "identity": "AWS.Lambda.Serverless.DetectImageLabels.CSharp",
   "groupIdentity": "AWS.Lambda.Serverless.DetectImageLabels",
   "shortName": "serverless.DetectImageLabels",

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleS3FunctionServerless-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleS3FunctionServerless-FSharp/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Serverless Simple S3 Function",
+  "name": "Lambda Serverless Simple S3 Function",
   "identity": "AWS.Serverless.Simple.S3.FSharp",
   "groupIdentity": "AWS.Serverless.Simple.S3",
   "shortName": "serverless.S3",

--- a/Blueprints/BlueprintDefinitions/vs2017/SimpleS3FunctionServerless/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2017/SimpleS3FunctionServerless/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Serverless Simple S3 Function",
+  "name": "Lambda Serverless Simple S3 Function",
   "identity": "AWS.Serverless.Simple.S3.CSharp",
   "groupIdentity": "AWS.Serverless.Simple.S3",
   "shortName": "serverless.S3",

--- a/Blueprints/BlueprintDefinitions/vs2017/StepFunctionsHelloWorld-FSharp/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2017/StepFunctionsHelloWorld-FSharp/blueprint-manifest.json
@@ -1,5 +1,5 @@
 {
-  "display-name": "Step Functions Hello World",
+  "display-name": "Lambda Step Functions Hello World",
   "system-name": "StepFunctionsHelloWorld",
   "description": "A simple example of how to build a .NET Core Lambda Step Function project.",
   "sort-order": 101,

--- a/Blueprints/BlueprintDefinitions/vs2017/StepFunctionsHelloWorld-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2017/StepFunctionsHelloWorld-FSharp/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Step Functions Hello World",
+  "name": "Lambda Step Functions Hello World",
   "identity": "AWS.Lambda.Serverless.StepFunctionsHelloWorld.FSharp",
   "groupIdentity": "AWS.Lambda.Serverless.StepFunctionsHelloWorld",
   "shortName": "serverless.StepFunctionsHelloWorld",

--- a/Blueprints/BlueprintDefinitions/vs2017/StepFunctionsHelloWorld-FSharp/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2017/StepFunctionsHelloWorld-FSharp/template/src/BlueprintBaseName.1/Readme.md
@@ -1,4 +1,4 @@
-# Step Functions Hello World
+# Lambda Step Functions Hello World
 
 This starter project consists of:
 

--- a/Blueprints/BlueprintDefinitions/vs2017/StepFunctionsHelloWorld/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2017/StepFunctionsHelloWorld/blueprint-manifest.json
@@ -1,5 +1,5 @@
 {
-  "display-name": "Step Functions Hello World",
+  "display-name": "Lambda Step Functions Hello World",
   "system-name": "StepFunctionsHelloWorld",
   "description": "A simple example of how to build a .NET Core Lambda Step Function project.",
   "sort-order": 101,

--- a/Blueprints/BlueprintDefinitions/vs2017/StepFunctionsHelloWorld/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2017/StepFunctionsHelloWorld/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Step Functions Hello World",
+  "name": "Lambda Step Functions Hello World",
   "identity": "AWS.Lambda.Serverless.StepFunctionsHelloWorld.CSharp",
   "groupIdentity": "AWS.Lambda.Serverless.StepFunctionsHelloWorld",
   "shortName": "serverless.StepFunctionsHelloWorld",

--- a/Blueprints/BlueprintDefinitions/vs2017/StepFunctionsHelloWorld/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2017/StepFunctionsHelloWorld/template/src/BlueprintBaseName.1/Readme.md
@@ -1,4 +1,4 @@
-# Step Functions Hello World
+# Lambda Step Functions Hello World
 
 This starter project consists of:
 

--- a/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabelsServerless-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabelsServerless-FSharp/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Serverless Detect Image Labels",
+  "name": "Lambda Serverless Detect Image Labels",
   "identity": "AWS.Lambda.Serverless.DetectImageLabels.FSharp",
   "groupIdentity": "AWS.Lambda.Serverless.DetectImageLabels",
   "shortName": "serverless.DetectImageLabels",

--- a/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabelsServerless/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2019/DetectImageLabelsServerless/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Serverless Detect Image Labels",
+  "name": "Lambda Serverless Detect Image Labels",
   "identity": "AWS.Lambda.Serverless.DetectImageLabels.CSharp",
   "groupIdentity": "AWS.Lambda.Serverless.DetectImageLabels",
   "shortName": "serverless.DetectImageLabels",

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleS3FunctionServerless-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleS3FunctionServerless-FSharp/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Serverless Simple S3 Function",
+  "name": "Lambda Serverless Simple S3 Function",
   "identity": "AWS.Serverless.Simple.S3.FSharp",
   "groupIdentity": "AWS.Serverless.Simple.S3",
   "shortName": "serverless.S3",

--- a/Blueprints/BlueprintDefinitions/vs2019/SimpleS3FunctionServerless/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2019/SimpleS3FunctionServerless/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Serverless Simple S3 Function",
+  "name": "Lambda Serverless Simple S3 Function",
   "identity": "AWS.Serverless.Simple.S3.CSharp",
   "groupIdentity": "AWS.Serverless.Simple.S3",
   "shortName": "serverless.S3",

--- a/Blueprints/BlueprintDefinitions/vs2019/StepFunctionsHelloWorld-FSharp/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2019/StepFunctionsHelloWorld-FSharp/blueprint-manifest.json
@@ -1,5 +1,5 @@
 {
-  "display-name": "Step Functions Hello World",
+  "display-name": "Lambda Step Functions Hello World",
   "system-name": "StepFunctionsHelloWorld",
   "description": "A simple example of how to build a .NET Core Lambda Step Function project.",
   "sort-order": 200,

--- a/Blueprints/BlueprintDefinitions/vs2019/StepFunctionsHelloWorld-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2019/StepFunctionsHelloWorld-FSharp/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Step Functions Hello World",
+  "name": "Lambda Step Functions Hello World",
   "identity": "AWS.Lambda.Serverless.StepFunctionsHelloWorld.FSharp",
   "groupIdentity": "AWS.Lambda.Serverless.StepFunctionsHelloWorld",
   "shortName": "serverless.StepFunctionsHelloWorld",

--- a/Blueprints/BlueprintDefinitions/vs2019/StepFunctionsHelloWorld-FSharp/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2019/StepFunctionsHelloWorld-FSharp/template/src/BlueprintBaseName.1/Readme.md
@@ -1,4 +1,4 @@
-# Step Functions Hello World
+# Lambda Step Functions Hello World
 
 This starter project consists of:
 

--- a/Blueprints/BlueprintDefinitions/vs2019/StepFunctionsHelloWorld/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2019/StepFunctionsHelloWorld/blueprint-manifest.json
@@ -1,5 +1,5 @@
 {
-  "display-name": "Step Functions Hello World",
+  "display-name": "Lambda Step Functions Hello World",
   "system-name": "StepFunctionsHelloWorld",
   "description": "A simple example of how to build a .NET Core Lambda Step Function project.",
   "sort-order": 200,

--- a/Blueprints/BlueprintDefinitions/vs2019/StepFunctionsHelloWorld/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2019/StepFunctionsHelloWorld/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Step Functions Hello World",
+  "name": "Lambda Step Functions Hello World",
   "identity": "AWS.Lambda.Serverless.StepFunctionsHelloWorld.CSharp",
   "groupIdentity": "AWS.Lambda.Serverless.StepFunctionsHelloWorld",
   "shortName": "serverless.StepFunctionsHelloWorld",

--- a/Blueprints/BlueprintDefinitions/vs2019/StepFunctionsHelloWorld/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2019/StepFunctionsHelloWorld/template/src/BlueprintBaseName.1/Readme.md
@@ -1,4 +1,4 @@
-# Step Functions Hello World
+# Lambda Step Functions Hello World
 
 This starter project consists of:
 

--- a/Blueprints/BlueprintDefinitions/vs2019/WebSocketAPIServerless/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2019/WebSocketAPIServerless/blueprint-manifest.json
@@ -1,7 +1,7 @@
 {
   "display-name": "WebSocket API",
   "system-name": "EmptyServerless",
-  "description": "Build a serverless WebSocket API using API Gateway.",
+  "description": "Build a Lambda Serverless WebSocket API using API Gateway.",
   "sort-order": 200,
   "hidden-tags": [
     "C#",

--- a/Blueprints/BlueprintDefinitions/vs2019/WebSocketAPIServerless/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2019/WebSocketAPIServerless/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Serverless WebSocket API",
+  "name": "Lambda Serverless WebSocket API",
   "identity": "AWS.Lambda.Serverless.WebSocketAPI.CSharp",
   "groupIdentity": "AWS.Lambda.Serverless.WebSocketAPI",
   "shortName": "serverless.WebSocketAPI",

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless-FSharp/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Serverless Detect Image Labels",
+  "name": "Lambda Serverless Detect Image Labels",
   "identity": "AWS.Lambda.Serverless.DetectImageLabels.FSharp",
   "groupIdentity": "AWS.Lambda.Serverless.DetectImageLabels",
   "shortName": "serverless.DetectImageLabels",

--- a/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/DetectImageLabelsServerless/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Serverless Detect Image Labels",
+  "name": "Lambda Serverless Detect Image Labels",
   "identity": "AWS.Lambda.Serverless.DetectImageLabels.CSharp",
   "groupIdentity": "AWS.Lambda.Serverless.DetectImageLabels",
   "shortName": "serverless.DetectImageLabels",

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless-FSharp/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Serverless project configured for deployment using .NET 7's Native AOT feature.",
+  "name": "Lambda Serverless project configured for deployment using .NET 7's Native AOT feature.",
   "identity": "AWS.Serverless.NativeAot.FSharp",
   "groupIdentity": "AWS.Serverless.NativeAOT",
   "shortName": "serverless.NativeAOT",

--- a/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/NativeAOTServerless/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Serverless project configured for deployment using .NET 7's Native AOT feature.",
+  "name": "Lambda Serverless project configured for deployment using .NET 7's Native AOT feature.",
   "identity": "AWS.Serverless.NativeAOT.CSharp",
   "groupIdentity": "AWS.Serverless.NativeAOT",
   "shortName": "serverless.NativeAOT",

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless-FSharp/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Serverless Simple S3 Function",
+  "name": "Lambda Serverless Simple S3 Function",
   "identity": "AWS.Serverless.Simple.S3.FSharp",
   "groupIdentity": "AWS.Serverless.Simple.S3",
   "shortName": "serverless.S3",

--- a/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/SimpleS3FunctionServerless/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Serverless Simple S3 Function",
+  "name": "Lambda Serverless Simple S3 Function",
   "identity": "AWS.Serverless.Simple.S3.CSharp",
   "groupIdentity": "AWS.Serverless.Simple.S3",
   "shortName": "serverless.S3",

--- a/Blueprints/BlueprintDefinitions/vs2022/StepFunctionsHelloWorld-FSharp/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/StepFunctionsHelloWorld-FSharp/blueprint-manifest.json
@@ -1,5 +1,5 @@
 {
-  "display-name": "Step Functions Hello World",
+  "display-name": "Lambda Step Functions Hello World",
   "system-name": "StepFunctionsHelloWorld",
   "description": "A simple example of how to build a .NET Core Lambda Step Function project.",
   "sort-order": 125,

--- a/Blueprints/BlueprintDefinitions/vs2022/StepFunctionsHelloWorld-FSharp/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/StepFunctionsHelloWorld-FSharp/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Step Functions Hello World",
+  "name": "Lambda Step Functions Hello World",
   "identity": "AWS.Lambda.Serverless.StepFunctionsHelloWorld.FSharp",
   "groupIdentity": "AWS.Lambda.Serverless.StepFunctionsHelloWorld",
   "shortName": "serverless.StepFunctionsHelloWorld",

--- a/Blueprints/BlueprintDefinitions/vs2022/StepFunctionsHelloWorld-FSharp/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/StepFunctionsHelloWorld-FSharp/template/src/BlueprintBaseName.1/Readme.md
@@ -1,4 +1,4 @@
-# Step Functions Hello World
+# Lambda Step Functions Hello World
 
 This starter project consists of:
 

--- a/Blueprints/BlueprintDefinitions/vs2022/StepFunctionsHelloWorld/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/StepFunctionsHelloWorld/blueprint-manifest.json
@@ -1,5 +1,5 @@
 {
-  "display-name": "Step Functions Hello World",
+  "display-name": "Lambda Step Functions Hello World",
   "system-name": "StepFunctionsHelloWorld",
   "description": "A simple example of how to build a .NET Core Lambda Step Function project.",
   "sort-order": 125,

--- a/Blueprints/BlueprintDefinitions/vs2022/StepFunctionsHelloWorld/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/StepFunctionsHelloWorld/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Step Functions Hello World",
+  "name": "Lambda Step Functions Hello World",
   "identity": "AWS.Lambda.Serverless.StepFunctionsHelloWorld.CSharp",
   "groupIdentity": "AWS.Lambda.Serverless.StepFunctionsHelloWorld",
   "shortName": "serverless.StepFunctionsHelloWorld",

--- a/Blueprints/BlueprintDefinitions/vs2022/StepFunctionsHelloWorld/template/src/BlueprintBaseName.1/Readme.md
+++ b/Blueprints/BlueprintDefinitions/vs2022/StepFunctionsHelloWorld/template/src/BlueprintBaseName.1/Readme.md
@@ -1,4 +1,4 @@
-# Step Functions Hello World
+# Lambda Step Functions Hello World
 
 This starter project consists of:
 

--- a/Blueprints/BlueprintDefinitions/vs2022/WebSocketAPIServerless/blueprint-manifest.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/WebSocketAPIServerless/blueprint-manifest.json
@@ -1,7 +1,7 @@
 {
   "display-name": "WebSocket API",
   "system-name": "EmptyServerless",
-  "description": "Build a serverless WebSocket API using API Gateway.",
+  "description": "Build a Lambda Serverless WebSocket API using API Gateway.",
   "sort-order": 150,
   "hidden-tags": [
     "C#",

--- a/Blueprints/BlueprintDefinitions/vs2022/WebSocketAPIServerless/template/.template.config/template.json
+++ b/Blueprints/BlueprintDefinitions/vs2022/WebSocketAPIServerless/template/.template.config/template.json
@@ -5,7 +5,7 @@
     "Lambda",
     "Serverless"
   ],
-  "name": "Serverless WebSocket API",
+  "name": "Lambda Serverless WebSocket API",
   "identity": "AWS.Lambda.Serverless.WebSocketAPI.CSharp",
   "groupIdentity": "AWS.Lambda.Serverless.WebSocketAPI",
   "shortName": "serverless.WebSocketAPI",

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Repository for the AWS NuGet packages and Blueprints to support writing AWS Lamb
 For a history of releases view the [release change log](RELEASE.CHANGELOG.md)
 
 ## Table of Contents
-- [AWS Lambda for .NET Core ![Gitter](https://gitter.im/aws/aws-lambda-dotnet?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)](#aws-lambda-for-net-core-img-srchttpsbadgesgitterimjoin20chatsvg-altgitter)
+- [AWS Lambda for .NET Core ](#aws-lambda-for-net-core-)
   - [Table of Contents](#table-of-contents)
   - [NuGet Packages](#nuget-packages)
     - [Events](#events)
@@ -132,42 +132,36 @@ To see a list of the Lambda templates execute **dotnet new lambda --list**
 
 ```
 > dotnet new lambda --list                                                                                             
-Templates                                                 Short Name                              Language          Tags
-
----------------------------------------------------------------------------------------------------------------------------------------------------------
-Order Flowers Chatbot Tutorial                            lambda.OrderFlowersChatbot              [C#]              AWS/Lambda/Function
-
-Lambda Detect Image Labels                                lambda.DetectImageLabels                [C#], F#          AWS/Lambda/Function
-
-Lambda Empty Function                                     lambda.EmptyFunction                    [C#], F#          AWS/Lambda/Function
-
-Lex Book Trip Sample                                      lambda.LexBookTripSample                [C#]              AWS/Lambda/Function
-
-Lambda Simple DynamoDB Function                           lambda.DynamoDB                         [C#], F#          AWS/Lambda/Function
-
-Lambda Simple Kinesis Firehose Function                   lambda.KinesisFirehose                  [C#]              AWS/Lambda/Function
-
-Lambda Simple Kinesis Function                            lambda.Kinesis                          [C#], F#          AWS/Lambda/Function
-
-Lambda Simple S3 Function                                 lambda.S3                               [C#], F#          AWS/Lambda/Function
-
-Lambda Simple SQS Function                                lambda.SQS                              [C#]              AWS/Lambda/Function
-
-Lambda ASP.NET Core Web API                               serverless.AspNetCoreWebAPI             [C#], F#          AWS/Lambda/Serverless
-
-Lambda ASP.NET Core Web Application with Razor Pages      serverless.AspNetCoreWebApp             [C#]              AWS/Lambda/Serverless
-
-Serverless Detect Image Labels                            serverless.DetectImageLabels            [C#], F#          AWS/Lambda/Serverless
-
-Lambda DynamoDB Blog API                                  serverless.DynamoDBBlogAPI              [C#]              AWS/Lambda/Serverless
-
-Lambda Empty Serverless                                   serverless.EmptyServerless              [C#], F#          AWS/Lambda/Serverless
-
-Lambda Giraffe Web App                                    serverless.Giraffe                      F#                AWS/Lambda/Serverless
-
-Serverless Simple S3 Function                             serverless.S3                           [C#], F#          AWS/Lambda/Serverless
-
-Step Functions Hello World                                serverless.StepFunctionsHelloWorld      [C#], F#          AWS/Lambda/Serverless
+Template Name                                                   Short Name                                    Language    Tags
+--------------------------------------------------------------  --------------------------------------------  --------    ---------------------
+Empty Top-level Function                                        lambda.EmptyTopLevelFunction                  [C#]        AWS/Lambda/Serverless
+Lambda Annotations Framework (Preview)                          serverless.Annotations                        [C#]        AWS/Lambda/Serverless
+Lambda ASP.NET Core Minimal API                                 serverless.AspNetCoreMinimalAPI               [C#]        AWS/Lambda/Serverless
+Lambda ASP.NET Core Web API                                     serverless.AspNetCoreWebAPI                   [C#],F#     AWS/Lambda/Serverless
+Lambda ASP.NET Core Web API (.NET 6 Container Image)            serverless.image.AspNetCoreWebAPI             [C#],F#     AWS/Lambda/Serverless
+Lambda ASP.NET Core Web Application with Razor Pages            serverless.AspNetCoreWebApp                   [C#]        AWS/Lambda/Serverless
+Lambda Custom Runtime Function (.NET 7)                         lambda.CustomRuntimeFunction                  [C#],F#     AWS/Lambda/Function
+Lambda Detect Image Labels                                      lambda.DetectImageLabels                      [C#],F#     AWS/Lambda/Function
+Lambda Empty Function                                           lambda.EmptyFunction                          [C#],F#     AWS/Lambda/Function
+Lambda Empty Function (.NET 7 Container Image)                  lambda.image.EmptyFunction                    [C#],F#     AWS/Lambda/Function
+Lambda Empty Serverless                                         serverless.EmptyServerless                    [C#],F#     AWS/Lambda/Serverless
+Lambda Empty Serverless (.NET 7 Container Image)                serverless.image.EmptyServerless              [C#],F#     AWS/Lambda/Serverless
+Lambda Function project configured for deployment using .NE...  lambda.NativeAOT                              [C#],F#     AWS/Lambda/Function
+Lambda Giraffe Web App                                          serverless.Giraffe                            F#          AWS/Lambda/Serverless
+Lambda Simple Application Load Balancer Function                lambda.SimpleApplicationLoadBalancerFunction  [C#]        AWS/Lambda/Function
+Lambda Simple DynamoDB Function                                 lambda.DynamoDB                               [C#],F#     AWS/Lambda/Function
+Lambda Simple Kinesis Firehose Function                         lambda.KinesisFirehose                        [C#]        AWS/Lambda/Function
+Lambda Simple Kinesis Function                                  lambda.Kinesis                                [C#],F#     AWS/Lambda/Function
+Lambda Simple S3 Function                                       lambda.S3                                     [C#],F#     AWS/Lambda/Function
+Lambda Simple SNS Function                                      lambda.SNS                                    [C#]        AWS/Lambda/Function
+Lambda Simple SQS Function                                      lambda.SQS                                    [C#]        AWS/Lambda/Function
+Lex Book Trip Sample                                            lambda.LexBookTripSample                      [C#]        AWS/Lambda/Function
+Order Flowers Chatbot Tutorial                                  lambda.OrderFlowersChatbot                    [C#]        AWS/Lambda/Function
+Serverless Detect Image Labels                                  serverless.DetectImageLabels                  [C#],F#     AWS/Lambda/Serverless
+Serverless project configured for deployment using .NET 7's...  serverless.NativeAOT                          [C#],F#     AWS/Lambda/Serverless
+Serverless Simple S3 Function                                   serverless.S3                                 [C#],F#     AWS/Lambda/Serverless
+Serverless WebSocket API                                        serverless.WebSocketAPI                       [C#]        AWS/Lambda/Serverless
+Step Functions Hello World                                      serverless.StepFunctionsHelloWorld            [C#],F#     AWS/Lambda/Serverless
 ```
 
 To get details about a template, you can use the help command.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Some templates didn't have the word "Lambda" in them, so they don't show when `dotnet new lambda --list` is run. 

Added "Lambda" to these templates.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
